### PR TITLE
Rename 'create' to 'encode' and fix critical bug.

### DIFF
--- a/Hashlink.js
+++ b/Hashlink.js
@@ -70,8 +70,6 @@ export class Hashlink {
         throw new Error(`Unknown cryptographic hash encoder "${encoder}".`);
       }
 
-      console.log("RUNNING ENCODER", encoder);
-
       return encoder.encode(await output);
     }, data);
 
@@ -102,8 +100,6 @@ export class Hashlink {
         this.registeredCodecs[baseEncodingCodec].encode(cborData));
       hashlink += ':' + mbCborData;
     }
-
-    console.log("DATA TO ENCODE", "DATA", data, "URLS", urls, "CODECS", codecs, "META", meta, "METADATA", metadata);
 
     return hashlink;
   }
@@ -170,7 +166,6 @@ export class Hashlink {
     const generatedComponents = generatedHashlink.split(':');
 
     // check to see if the encoded hashes match
-    console.log("DATA", data, "EXPECTED", components[1], "GOT", generatedComponents[1]);
     return components[1] === generatedComponents[1];
   }
 

--- a/README.md
+++ b/README.md
@@ -86,33 +86,33 @@ npm install
 
 Use on the command line, or see the API section below.
 
-### Creating a Hashlink
+### Encoding a Hashlink
 
-There are a number of ways you can create a hashlink. The simplest way is to
+There are a number of ways you can encode a hashlink. The simplest way is to
 provide the data directly.
 
 ```bash
-./bin/hl create hw.txt
+./bin/hl encode hw.txt
 ```
 
-You can create a hashlink from any data published on the Web:
+You can encode a hashlink from any data published on the Web:
 
 ```bash
-./bin/hl create --url "https://example.com/hw.txt"
+./bin/hl encode --url "https://example.com/hw.txt"
 ```
 
-You can also create a hashlink from data on disk and specify the location on
+You can also encode a hashlink from data on disk and specify the location on
 the web that the data will be published to:
 
 ```bash
-./bin/hl create --url "https://example.com/hw.txt" hw.txt
+./bin/hl encode --url "https://example.com/hw.txt" hw.txt
 ```
 
 Hashlinks are also backwards compatible with legacy URL schemes, which enables
 you to use query parameters to encode the hashlink information:
 
 ```bash
-./bin/hl create --legacy --url "https://example.com/hw.txt" hw.txt
+./bin/hl encode --legacy --url "https://example.com/hw.txt" hw.txt
 ```
 
 ### Decoding a Hashlink
@@ -158,31 +158,31 @@ via a simple script tag:
 The rest of the examples in this section assume a node.js environment, but
 all API calls listed below are also available in the browser version.
 
-### Creating a Hashlink
+### Encoding a Hashlink
 
-You can create a hashlink from an existing URL (**coming soon**):
+You can encode a hashlink from an existing URL (**coming soon**):
 
 ```js
 const hl = require('hashlink');
 
 const url = 'https://example.com/hw.txt';
 
-// create a hashlink by fetching the URL content and hashing it
-const hlUrl = await hl.create({url});
+// encode a hashlink by fetching the URL content and hashing it
+const hlUrl = await hl.encode({url});
 
 // print out the hashlink
 console.log(hlUrl);
 ```
 
-You can create a hashlink from data:
+You can encode a hashlink from data:
 
 ```js
 const hl = require('hashlink');
 
-// create a hashlink using data to be published at a URL
+// encode a hashlink using data to be published at a URL
 const data = fs.readFileSync('hw.txt');
 const url = 'https://example.com/hw.txt';
-const hlUrl = await hl.create({data, url});
+const hlUrl = await hl.encode({data, url});
 
 // print out the hashlink
 console.log(hlUrl);
@@ -198,12 +198,12 @@ const {Urdna2015} = require('hashlink-jsonld');
 const hl = new Hashlink();
 hl.use(new Urdna2015());
 
-// create a hashlink using canonicalized data published at a URL
+// encode a hashlink using canonicalized data published at a URL
 const url = 'https://example.com/credential.jsonld';
 // encode the input data using urdna2015 canonicalization algorithm and
 // then hash using blake2b with a 64-bit output
 const codecs = ['urdna2015', 'blake2b-64'];
-const hlUrl = await hl.create({
+const hlUrl = await hl.encode({
   url,
   codecs,
   'content-type': 'application/ld+json'
@@ -255,7 +255,7 @@ const {Urdna2016} = require('hashlink-jsonld');
 const hl = new Hashlink();
 hl.use(new Urdna2015());
 
-// create a hashlink using canonicalized data published at a URL
+// encode a hashlink using canonicalized data published at a URL
 const hlUrl = 'hl:zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e:' +
   'zuh8iaLobXC8g9tfma1CSTtYBakXeSTkHrYA5hmD4F7dCLw8XYwZ1GWyJ3zwF';
 const valid = await hl.verify({hashlink: hlUrl});
@@ -274,7 +274,7 @@ defaults work just fine.
 
 ```js
 const hl = require('hashlink');
-const hlUrl = await hl.create({url: 'https://example.com/hw.txt'});
+const hlUrl = await hl.encode({url: 'https://example.com/hw.txt'});
 ```
 
 In some cases, however, a developer will need to extend the default
@@ -302,13 +302,13 @@ class Urdna2015 {
 const hl = new Hashlink();
 hl.use(new Urdna2015());
 
-// create a hashlink using canonicalized data published at a URL
+// encode a hashlink using canonicalized data published at a URL
 const url = 'https://example.com/credential.jsonld';
 
 // encode the input data using urdna2015 canonicalization algorithm and
 // then hash using blake2b with a 64-bit output
 const codecs = ['urdna2015', 'blake2b-64'];
-const hlUrl = await hl.create({
+const hlUrl = await hl.encode({
   url,
   codecs,
   'content-type': 'application/ld+json'

--- a/bin/hl
+++ b/bin/hl
@@ -10,11 +10,11 @@ function collect(value, previous) {
 }
 
 program
-  .command('create')
-  .alias('c')
-  .description('Create a hashlink given a URL and/or data.')
+  .command('encode')
+  .alias('e')
+  .description('Encode a hashlink given a URL and/or data.')
   .option('-u, --url <location>', 'target URL for the hashlink', collect, [])
-  .option('-l, --legacy', 'create a hashlink for a legacy URL')
+  .option('-l, --legacy', 'encode a hashlink for a legacy URL')
   .option('-h, --hash <algorithm>', 'cryptographic hash algorithm', 'sha2-256')
   .option('-b, --base <encoding>', 'base encoding', 'base58-btc')
   .action(async (dataFile, options) => {
@@ -29,7 +29,7 @@ program
       }
       // generate codecs from command line options
       codecs = ['mh-' + options.hash, 'mb-' + options.base];
-      const hashlink = await hl.create({data, urls, codecs, meta});
+      const hashlink = await hl.encode({data, urls, codecs, meta});
 
       if(options.legacy) {
         // print out a legacy hashlink
@@ -52,9 +52,9 @@ program
     console.log();
     console.log('  Examples: ');
     console.log();
-    console.log('    hl create hw.txt');
-    console.log('    hl create --url "https://example.com/hw.txt"');
-    console.log('    hl create --url "https://example.com/hw.txt" hw.txt');
+    console.log('    hl encode hw.txt');
+    console.log('    hl encode --url "https://example.com/hw.txt"');
+    console.log('    hl encode --url "https://example.com/hw.txt" hw.txt');
     console.log();
   });
 

--- a/codecs.js
+++ b/codecs.js
@@ -37,6 +37,8 @@ class MultihashSha2256 {
     mhsha2256.set(this.identifier, 0);
     mhsha2256.set(sha2256, this.identifier.byteLength);
 
+    console.log("SHA2256 ENCODE", "INPUT", input, "SHA2256", sha2256, "MHSHA2256", mhsha2256);
+
     return mhsha2256;
   }
 }

--- a/codecs.js
+++ b/codecs.js
@@ -30,14 +30,12 @@ class MultihashSha2256 {
    */
   async encode(input) {
     const sha2256 = new Uint8Array(
-      await crypto.subtle.digest({name: 'SHA-256'}, input.buffer));
+      await crypto.subtle.digest({name: 'SHA-256'}, input));
     const mhsha2256 = new Uint8Array(
       sha2256.byteLength + this.identifier.byteLength);
 
     mhsha2256.set(this.identifier, 0);
     mhsha2256.set(sha2256, this.identifier.byteLength);
-
-    console.log("SHA2256 ENCODE", "INPUT", input, "SHA2256", sha2256, "MHSHA2256", mhsha2256);
 
     return mhsha2256;
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,7 @@
       // get element to write hashlink value into
       const hlElement = document.getElementById('hlvalue');
       // write hashlink value into element
-      hlElement.innerHTML = await window.hashlink.create({data});
+      hlElement.innerHTML = await window.hashlink.encode({data});
     }
   </script>
 

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ import {Hashlink} from './Hashlink.js';
 // setup exports for this module
 export {Hashlink} from './Hashlink.js';
 export {
-  create,
+  encode,
   decode,
   verify,
 };
@@ -24,13 +24,13 @@ hlDefault.use(new defaultCodecs.MultihashBlake2b64());
 hlDefault.use(new defaultCodecs.MultibaseBase58btc());
 
 /**
- * Creates a hashlink. If only a `url` parameter is provided, the URL is
+ * Encodes a hashlink. If only a `url` parameter is provided, the URL is
  * fetched, transformed, and encoded into a hashlink. If a data parameter
- * is provided, the hashlink is created from the data.
+ * is provided, the hashlink is encoded from the data.
  *
- * @param {Object} options - The options for the create operation.
+ * @param {Object} options - The options for the encode operation.
  * @param {Uint8Array} options.data - The data associated with the given URL. If
- *   provided, this data is used to create the cryptographic hash.
+ *   provided, this data is used to encode the cryptographic hash.
  * @param {Array} options.urls - One or more URLs that contain the data
  *   referred to by the hashlink.
  * @param {Array} options.codecs - One or more URLs that contain the data
@@ -40,21 +40,21 @@ hlDefault.use(new defaultCodecs.MultibaseBase58btc());
  *
  * @returns {Promise<string>} Resolves to a string that is a hashlink.
  */
-async function create({data, urls, url,
+async function encode({data, urls, url,
   codecs = ['mh-sha2-256', 'mb-base58-btc'], meta = {}}) {
 
   if(url && !urls) {
     urls = [url];
   }
 
-  return await hlDefault.create({data, urls, codecs, meta});
+  return await hlDefault.encode({data, urls, codecs, meta});
 }
 
 /**
  * Decodes a hashlink resulting in an object with key-value pairs
  * representing the values encoded in the hashlink.
  *
- * @param {Object} options - The options for the create operation.
+ * @param {Object} options - The options for the encode operation.
  * @param {string} options.hashlink - The encoded hashlink value to decode.
  *
  * @returns {Object} Returns an object with the decoded hashlink values.
@@ -66,7 +66,7 @@ function decode({hashlink}) {
 /**
  * Verifies a hashlink resulting in a simple true or false value.
  *
- * @param {Object} options - The options for the create operation.
+ * @param {Object} options - The options for the encode operation.
  * @param {string} options.hashlink - The encoded hashlink value to verify.
  * @param {Uint8Array} options.data - Optional data to use when verifying
  *   hashlink.

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -41,14 +41,14 @@ describe('hashlink library', function() {
   }
 
   describe(`Hashlink class`, function() {
-    describe(`create() [sha2-256]`, function() {
+    describe(`encode() [sha2-256]`, function() {
       // setup the encoder/decoder
       const hlInstance = new Hashlink();
       hlInstance.use(new defaultCodecs.MultihashSha2256());
       hlInstance.use(new defaultCodecs.MultibaseBase58btc());
 
-      it('create({data, codecs}) should create a hashlink', async function() {
-        const result = await hlInstance.create({
+      it('encode({data, codecs}) should encode a hashlink', async function() {
+        const result = await hlInstance.encode({
           data: testData,
           codecs: ['mh-sha2-256', 'mb-base58-btc']
         });
@@ -57,9 +57,9 @@ describe('hashlink library', function() {
           'hl:zQmNbCYUrvaVfy6w9b5W3SVTP2newPK5FoeY37QurUEUydH');
       });
 
-      it('create({data, urls, codecs}) should create a hashlink',
+      it('encode({data, urls, codecs}) should encode a hashlink',
         async function() {
-        const result = await hlInstance.create({
+        const result = await hlInstance.encode({
           data: testData,
           urls: [exampleUrl],
           codecs: ['mh-sha2-256', 'mb-base58-btc']
@@ -70,9 +70,9 @@ describe('hashlink library', function() {
           'z3TSgXTuaHxY2tsArhUreJ4ixgw9NW7DYuQ9QTPQyLHy');
       });
 
-      it('create({data, urls, meta, codecs}) should create a hashlink',
+      it('encode({data, urls, meta, codecs}) should encode a hashlink',
         async function() {
-        const result = await hlInstance.create({
+        const result = await hlInstance.encode({
           data: testData,
           urls: [exampleUrl],
           meta: {
@@ -87,14 +87,14 @@ describe('hashlink library', function() {
       });
     });
 
-    describe(`create API (blake2b-64)`, function() {
+    describe(`encode() [blake2b-64]`, function() {
       // setup the encoder/decoder
       const hlInstance = new Hashlink();
       hlInstance.use(new defaultCodecs.MultihashBlake2b64());
       hlInstance.use(new defaultCodecs.MultibaseBase58btc());
 
-      it('create({data, codecs}) should create a hashlink', async function() {
-        const result = await hlInstance.create({
+      it('encode({data, codecs}) should encode a hashlink', async function() {
+        const result = await hlInstance.encode({
           data: testData,
           codecs: ['mh-blake2b-64', 'mb-base58-btc']
         });
@@ -102,9 +102,9 @@ describe('hashlink library', function() {
         result.should.equal('hl:zm9YZpCjPLPJ4Epc');
       });
 
-      it('create({data, urls, codecs}) should create a hashlink',
+      it('encode({data, urls, codecs}) should encode a hashlink',
         async function() {
-        const result = await hlInstance.create({
+        const result = await hlInstance.encode({
           data: testData,
           urls: [exampleUrl],
           codecs: ['mh-blake2b-64', 'mb-base58-btc']
@@ -115,9 +115,9 @@ describe('hashlink library', function() {
           'z3TSgXTuaHxY2tsArhUreJ4ixgw9NW7DYuQ9QTPQyLHy');
       });
 
-      it('create({data, urls, meta, codecs}) should create a hashlink',
+      it('encode({data, urls, meta, codecs}) should encode a hashlink',
         async function() {
-        const result = await hlInstance.create({
+        const result = await hlInstance.encode({
           data: testData,
           urls: [exampleUrl],
           meta: {
@@ -132,47 +132,51 @@ describe('hashlink library', function() {
       });
     });
 
-    describe(`create() [blake2b-64]`, function() {
+    describe(`encode() [urdna2015]`, function() {
       // setup the encoder/decoder
       const hlInstance = new Hashlink();
+      hlInstance.use(new Urdna2015());
       hlInstance.use(new defaultCodecs.MultihashBlake2b64());
       hlInstance.use(new defaultCodecs.MultibaseBase58btc());
 
-      it('create({data, codecs}) should create a hashlink', async function() {
-        const result = await hlInstance.create({
-          data: testData,
-          codecs: ['mh-blake2b-64', 'mb-base58-btc']
+      it('encode({data, codecs}) should encode a hashlink', async function() {
+        const result = await hlInstance.encode({
+          data: stringToUint8Array(JSON.stringify(jsonldData)),
+          codecs: ['urdna2015', 'mh-blake2b-64', 'mb-base58-btc'],
+          transform: ['urdna2015']
         });
 
-        result.should.equal('hl:zm9YZpCjPLPJ4Epc');
+        result.should.equal('hl:zm9YaHWNePhdaQ2J');
       });
 
-      it('create({data, urls, codecs}) should create a hashlink',
+      it('encode({data, urls, codecs}) should encode a hashlink',
         async function() {
-        const result = await hlInstance.create({
-          data: testData,
+        const result = await hlInstance.encode({
+          data: stringToUint8Array(JSON.stringify(jsonldData)),
           urls: [exampleUrl],
-          codecs: ['mh-blake2b-64', 'mb-base58-btc']
+          codecs: ['urdna2015', 'mh-blake2b-64', 'mb-base58-btc'],
+          transform: ['urdna2015']
         });
 
         result.should.equal(
-          'hl:zm9YZpCjPLPJ4Epc:' +
+          'hl:zm9YaHWNePhdaQ2J:' +
           'z3TSgXTuaHxY2tsArhUreJ4ixgw9NW7DYuQ9QTPQyLHy');
       });
 
-      it('create({data, urls, meta, codecs}) should create a hashlink',
+      it('encode({data, urls, meta, codecs}) should encode a hashlink',
         async function() {
-        const result = await hlInstance.create({
-          data: testData,
+        const result = await hlInstance.encode({
+          data: stringToUint8Array(JSON.stringify(jsonldData)),
           urls: [exampleUrl],
           meta: {
             'content-type': 'text/plain'
           },
-          codecs: ['mh-blake2b-64', 'mb-base58-btc']
+          codecs: ['urdna2015', 'mh-blake2b-64', 'mb-base58-btc'],
+          transform: ['urdna2015']
         });
 
         result.should.equal(
-          'hl:zm9YZpCjPLPJ4Epc:' +
+          'hl:zm9YaHWNePhdaQ2J:' +
           'zCwPSdabLuj3jue1qYujzunnKwpL4myKdyeqySyFhnzZ8qdfW3bb6W8dVdRu');
       });
     });
@@ -238,7 +242,7 @@ describe('hashlink library', function() {
       hlInstance.use(new defaultCodecs.MultibaseBase58btc());
 
       it('use() with custom JSON-LD transform', async function() {
-        const result = await hlInstance.create({
+        const result = await hlInstance.encode({
           data: stringToUint8Array(JSON.stringify(jsonldData)),
           codecs: ['urdna2015', 'mh-sha2-256', 'mb-base58-btc']
         });
@@ -250,10 +254,10 @@ describe('hashlink library', function() {
   });
 
   describe(`convenience functionality`, function() {
-    describe(`create()`, function() {
+    describe(`encode()`, function() {
 
-      it('create({data}) should create a hashlink', async function() {
-        const result = await hl.create({
+      it('encode({data}) should encode a hashlink', async function() {
+        const result = await hl.encode({
           data: testData
         });
 
@@ -261,9 +265,9 @@ describe('hashlink library', function() {
           'hl:zQmNbCYUrvaVfy6w9b5W3SVTP2newPK5FoeY37QurUEUydH');
       });
 
-      it('create({data, urls}) should create a hashlink',
+      it('encode({data, urls}) should encode a hashlink',
         async function() {
-        const result = await hl.create({
+        const result = await hl.encode({
           data: testData,
           urls: [exampleUrl]
         });
@@ -273,9 +277,9 @@ describe('hashlink library', function() {
           'z3TSgXTuaHxY2tsArhUreJ4ixgw9NW7DYuQ9QTPQyLHy');
       });
 
-      it('create({data, urls, meta}) should create a hashlink',
+      it('encode({data, urls, meta}) should encode a hashlink',
         async function() {
-        const result = await hl.create({
+        const result = await hl.encode({
           data: testData,
           urls: [exampleUrl],
           meta: {


### PR DESCRIPTION
This PR does the following things:

* Renames hl.create to hl.encode to bring it inline w/ hl.decode().
* Fixes a bug when passing a sha2-256 buffer during the encoding process.